### PR TITLE
Dashboard route usage corrected

### DIFF
--- a/qubell/api/private/organization.py
+++ b/qubell/api/private/organization.py
@@ -257,7 +257,7 @@ class Organization(Entity):
             warnings.warn("organization.list_instances_json(app) is deprecated, use app.list_instances_json", DeprecationWarning, stacklevel=2)
             instances = application.list_instances_json()
         else:  # Return all instances in organization
-            instances = router.get_instances(org_id=self.organizationId).json()
+            instances = router.get_instances(org_id=self.organizationId).json()['groups'][0]['records']
         return [ins for ins in instances if ins['status'] not in DEAD_STATUS]
 
     def get_or_create_instance(self, id=None, application=None, revision=None, environment=None, name=None, parameters=None, submodules=None,


### PR DESCRIPTION
`/organizations/{orgId}/dashboard.json` route usage corrected to retrieve list of all instances

**Note:** PR should be merged with https://github.com/qubell/vermilion/pull/3861 only