### PR TITLE
API: Application Revisions retrieving updated

### DIFF
--- a/qubell/api/private/application.py
+++ b/qubell/api/private/application.py
@@ -130,7 +130,8 @@ class Application(Entity, InstanceRouter):
         return rev
 
     def list_revisions_json(self):
-        return self.json()['revisions']
+        # return self.json()['revisions']
+        return self._router.get_revisions(org_id=self.organizationId, app_id=self.applicationId).json()
 
     def create_revision(self, name, instance=None, parameters={}, version=None, submodules={}):
         if not version:

--- a/qubell/api/provider/router.py
+++ b/qubell/api/provider/router.py
@@ -130,6 +130,10 @@ class PrivatePath(Router):
     def get_revision(self, org_id, app_id, rev_id, cookies, ctype=".json"): pass
 
     @play_auth
+    @route("GET /organizations/{org_id}/applications/{app_id}/revisions{ctype}")
+    def get_revisions(self, org_id, app_id, cookies, ctype=".json"): pass
+
+    @play_auth
     @route("DELETE /organizations/{org_id}/applications/{app_id}/revisions/{rev_id}{ctype}")
     def delete_revision(self, org_id, app_id, rev_id, cookies, data="{}", ctype=".json"): pass
 


### PR DESCRIPTION
API to get Application revisions updated to more correct one.
In near future (https://github.com/qubell/vermilion/pull/5116) `/applications/:id.json` will not return instances and revisions.