### PR TITLE
split delete_revision and delete_revision_with_check up

### DIFF
--- a/qubell/api/private/revision.py
+++ b/qubell/api/private/revision.py
@@ -61,10 +61,8 @@ class Revision(Entity, InstanceRouter):
     def json(self):
         return self._router.get_revision(org_id=self.organizationId, app_id=self.applicationId, rev_id=self.id).json()
 
-    def delete(self):
-        self._router.delete_revision(org_id=self.organizationId, app_id=self.applicationId, rev_id=self.id)
-        return True
-
+    def delete(self, force=True):
+        self._router.delete_revision(org_id=self.organizationId, app_id=self.applicationId, rev_id=self.id, force=force)
 
 class RevisionList(EntityList, InstanceRouter):
 

--- a/qubell/api/provider/router.py
+++ b/qubell/api/provider/router.py
@@ -141,8 +141,8 @@ class PrivatePath(Router):
     def get_revisions(self, org_id, app_id, cookies, ctype=".json"): pass
 
     @play_auth
-    @route("DELETE /organizations/{org_id}/applications/{app_id}/revisions/{rev_id}{ctype}")
-    def delete_revision(self, org_id, app_id, rev_id, cookies, data="{}", ctype=".json"): pass
+    @route("DELETE /organizations/{org_id}/applications/{app_id}/revisions/{rev_id}{ctype}?force={force}")
+    def delete_revision(self, org_id, app_id, rev_id, cookies, data="{}", force=True, ctype=".json"): pass
 
     @play_auth
     @route("DELETE /organizations/{org_id}/applications/{app_id}/destroyedInstances{ctype}")


### PR DESCRIPTION
New delete_revision_with_check api call which returns bad request and dependent revisions