### PR TITLE
Update router.py

### DIFF
--- a/qubell/api/provider/router.py
+++ b/qubell/api/provider/router.py
@@ -11,6 +11,8 @@ from qubell.api.globals import QUBELL as qubell_config
 class Router(object):
     def __init__(self, base_url=None, verify_ssl=False, verify_codes=True):
         self.base_url = base_url or qubell_config['tenant']
+        if self.base_url.endswith("/"):
+            self.base_url = self.base_url[:-1]
         self.verify_ssl = verify_ssl
         self.verify_codes = verify_codes
 

--- a/qubell/tests/provider/test_router.py
+++ b/qubell/tests/provider/test_router.py
@@ -28,3 +28,8 @@ class RouterTests(unittest.TestCase):
         with self.assertRaises(ApiUnauthorizedError) as context, patch("requests.session"):
             self.router.connect("any@where", "**wrong**")
         assert str(context.exception) == "Authentication failed, please check settings"
+    
+    def test_url_trim(self):
+        url = "http://router.org"
+        router = Router(url + "/")
+        assert self.router.base_url == url


### PR DESCRIPTION
Remove trailing slash if present in URL.
This normalization is required because double-slash causes authorization error in platform.