### PR TITLE
Inverted services destruction order

### DIFF
--- a/qubell/api/private/testing/sandbox_testcase.py
+++ b/qubell/api/private/testing/sandbox_testcase.py
@@ -136,7 +136,7 @@ class SandBoxTestCase(SetupOnce, unittest.TestCase):
         log.info("\n---------------  Cleaning sandbox  ---------------")
 
         self.destroy_instances(self.regular_instances)
-        self.destroy_instances(self.service_instances)
+        self.destroy_instances(reversed(self.service_instances))
         self.regular_instances = []
         self.service_instances = []
 


### PR DESCRIPTION
This is necessary when services depend on each other, for example:
```python
@applications([
    dict(name='Docker Service',
         file=os.path.realpath(os.path.join(os.path.dirname(__file__), "local-docker-service.yml")),
         add_as_service=True),
    dict(name='Docker Scripting Service',
         file=os.path.realpath(os.path.join(os.path.dirname(__file__), "scripting-service.yml")),
         add_as_service=True),
    dict(name='Virtual VM Factory',
         file=os.path.realpath(os.path.join(os.path.dirname(__file__), "virtual-vm-factory.yml")),
         add_as_service=True),
    dict(name='Virtual VM',
         file=os.path.realpath(os.path.join(os.path.dirname(__file__), "virtual-vm.yml")),
         launch=False)
])
```
Here `Virtual VM Factory` service depends on `Docker Scripting Service`, which depends on `Docker Service`. By default services are going to be destroyed in the forward order, but this won't work because of dependencies: Docker Service will wait until Docker Scripting Service is destroyed, but it will never happen because the script won't destroy Docker Scripting Service until Docker Service is destroyed. Reversing the order helps here.