### PR TITLE
Added reconfigure route and made use of it in the instance class

### DIFF
--- a/qubell/api/private/instance.py
+++ b/qubell/api/private/instance.py
@@ -402,23 +402,32 @@ class Instance(Entity, ServiceMixin, InstanceRouter):
         return self._router.post_application_refresh(org_id=self.organizationId, app_id=self.applicationId).json()
 
     def reconfigure(self, revision=None, parameters=None, submodules=None, manifestVersion=None):
-        # note: be carefull refactoring this, or you might have unpredictable results
-        # todo: private api seems requires at least presence of submodule names if exist
-        payload = {'parameters': self.parameters}
+        # if no parameters are specified, use an alternative, more concise API route
+        if not revision \
+           and parameters is None \
+           and not submodules \
+           and not manifestVersion:
+            resp = self._router.post_instance_reconfigure(org_id=self.organizationId, instance_id=self.instanceId)
+            return resp.json()
 
-        if revision:
-            payload['revisionId'] = revision.id
+        else:
+            # note: be carefull refactoring this, or you might have unpredictable results
+            # todo: private api seems requires at least presence of submodule names if exist
+            payload = {'parameters': self.parameters}
 
-        if submodules:
-            payload['submodules'] = submodules
-        if parameters is not None:
-            payload['parameters'] = parameters
-        if manifestVersion:
-            payload['manifestVersion'] = manifestVersion
+            if revision:
+                payload['revisionId'] = revision.id
 
-        resp = self._router.put_instance_configuration(org_id=self.organizationId, instance_id=self.instanceId,
-                                                       data=json.dumps(payload))
-        return resp.json()
+            if submodules:
+                payload['submodules'] = submodules
+            if parameters is not None:
+                payload['parameters'] = parameters
+            if manifestVersion:
+                payload['manifestVersion'] = manifestVersion
+
+            resp = self._router.put_instance_configuration(org_id=self.organizationId, instance_id=self.instanceId,
+                                                           data=json.dumps(payload))
+            return resp.json()
 
     def rename(self, name):
         payload = json.dumps({'name': name})

--- a/qubell/api/provider/router.py
+++ b/qubell/api/provider/router.py
@@ -188,6 +188,10 @@ class PrivatePath(Router):
     def get_instance_configuration(self, org_id, instance_id, cookies, ctype=".json"): pass
 
     @play_auth
+    @route("POST /organizations/{org_id}/instances/{instance_id}/reconfigure{ctype}")
+    def post_instance_reconfigure(self, org_id, instance_id, cookies, data="{}", ctype=".json"): pass
+
+    @play_auth
     @route("PUT /organizations/{org_id}/instances/{instance_id}/rename{ctype}")
     def put_instance_rename(self, org_id, instance_id, data, cookies, ctype=".json"): pass
 


### PR DESCRIPTION
Added `/reconfigure` route for instances which triggers instance reconfiguration with current parameters, and used it in `Instance.reconfigure()` method when no parameters are supplied. We don't use `reconfigure()` without parameters in our code base yet, so this should not break anything.